### PR TITLE
Add GitHub scraper for users and repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,47 @@
 # demo
+
+## Scraping Users and Repositories using the GitHub API
+
+This project scrapes users in the city of ${city} with over ${followers} followers and their repositories using the GitHub API. The data is saved in `users.csv` and `repositories.csv` files.
+
+### Instructions
+
+1. Install the required libraries:
+   ```
+   pip install requests
+   ```
+
+2. Run the script:
+   ```
+   python scrape_github.py
+   ```
+
+### Files
+
+- `users.csv`: Contains the following fields about each user:
+  - login: Their Github user ID
+  - name: Their full name
+  - company: The company they work at. Clean up company names. At least make sure:
+    - They're trimmed of whitespace
+    - Leading @ symbol is stripped (Note: ONLY the first one is stripped)
+    - They are converted to UPPERCASE
+  - location: The city they are in
+  - email: Their email address
+  - hireable: Whether they are open to being hired
+  - bio: A short bio about them
+  - public_repos: The number of public repositories they have
+  - followers: The number of followers they have
+  - following: The number of people they are following
+  - created_at: When they joined Github
+
+- `repositories.csv`: Contains the following fields about each repository:
+  - repository name
+  - description
+  - language
+  - created_at
+  - updated_at
+  - pushed_at
+  - stargazers_count
+  - watchers_count
+  - forks_count
+  - open_issues_count

--- a/repositories.csv
+++ b/repositories.csv
@@ -1,0 +1,1 @@
+repository name,description,language,created_at,updated_at,pushed_at,stargazers_count,watchers_count,forks_count,open_issues_count

--- a/scrape_github.py
+++ b/scrape_github.py
@@ -1,0 +1,105 @@
+import requests
+import csv
+
+# GitHub API base URL
+BASE_URL = "https://api.github.com"
+
+# Function to get users in the specified city with over the specified number of followers
+def get_users(city, followers):
+    users = []
+    page = 1
+    while True:
+        url = f"{BASE_URL}/search/users?q=location:{city}+followers:>{followers}&page={page}"
+        response = requests.get(url)
+        data = response.json()
+        if "items" not in data:
+            break
+        users.extend(data["items"])
+        if len(data["items"]) < 30:
+            break
+        page += 1
+    return users
+
+# Function to get user details
+def get_user_details(username):
+    url = f"{BASE_URL}/users/{username}"
+    response = requests.get(url)
+    return response.json()
+
+# Function to get repositories of a user
+def get_repositories(username):
+    repos = []
+    page = 1
+    while True:
+        url = f"{BASE_URL}/users/{username}/repos?page={page}"
+        response = requests.get(url)
+        data = response.json()
+        if not data:
+            break
+        repos.extend(data)
+        page += 1
+    return repos
+
+# Function to clean up company names
+def clean_company_name(company):
+    if company:
+        company = company.strip()
+        if company.startswith("@"):
+            company = company[1:]
+        company = company.upper()
+    return company
+
+# Function to save users to CSV
+def save_users_to_csv(users, filename):
+    with open(filename, mode='w', newline='', encoding='utf-8') as file:
+        writer = csv.writer(file)
+        writer.writerow(["login", "name", "company", "location", "email", "hireable", "bio", "public_repos", "followers", "following", "created_at"])
+        for user in users:
+            writer.writerow([
+                user["login"],
+                user["name"] or "",
+                clean_company_name(user["company"]),
+                user["location"] or "",
+                user["email"] or "",
+                user["hireable"] or "",
+                user["bio"] or "",
+                user["public_repos"],
+                user["followers"],
+                user["following"],
+                user["created_at"]
+            ])
+
+# Function to save repositories to CSV
+def save_repositories_to_csv(repositories, filename):
+    with open(filename, mode='w', newline='', encoding='utf-8') as file:
+        writer = csv.writer(file)
+        writer.writerow(["repository name", "description", "language", "created_at", "updated_at", "pushed_at", "stargazers_count", "watchers_count", "forks_count", "open_issues_count"])
+        for repo in repositories:
+            writer.writerow([
+                repo["name"],
+                repo["description"] or "",
+                repo["language"] or "",
+                repo["created_at"],
+                repo["updated_at"],
+                repo["pushed_at"],
+                repo["stargazers_count"],
+                repo["watchers_count"],
+                repo["forks_count"],
+                repo["open_issues_count"]
+            ])
+
+# Main function
+def main():
+    city = "San Francisco"
+    followers = 100
+    users = get_users(city, followers)
+    user_details = [get_user_details(user["login"]) for user in users]
+    save_users_to_csv(user_details, "users.csv")
+    all_repositories = []
+    for user in users:
+        repositories = get_repositories(user["login"])
+        all_repositories.extend(repositories)
+    save_repositories_to_csv(all_repositories, "repositories.csv")
+
+if __name__ == "__main__":
+    main()

--- a/users.csv
+++ b/users.csv
@@ -1,0 +1,1 @@
+login,name,company,location,email,hireable,bio,public_repos,followers,following,created_at


### PR DESCRIPTION
Add functionality to scrape GitHub users and repositories and save to CSV files.

* **README.md**: Add a section about scraping users and repositories using the GitHub API. Provide instructions on how to run the script. Mention the `users.csv` and `repositories.csv` files and their contents.
* **users.csv**: Create a CSV file with the required fields: login, name, company, location, email, hireable, bio, public_repos, followers, following, created_at.
* **repositories.csv**: Create a CSV file with the required fields: repository name, description, language, created_at, updated_at, pushed_at, stargazers_count, watchers_count, forks_count, open_issues_count.
* **scrape_github.py**: Create a Python script to scrape users and repositories using the GitHub API. Use the `requests` library to make API calls. Save the user data in `users.csv`. Save the repository data in `repositories.csv`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ashim1600/demo?shareId=2a6655cd-b67f-4562-9de4-3898474b0ae1).